### PR TITLE
bugfix: add "rb" and "encoding" to several with open clause

### DIFF
--- a/src/bokeh_sampledata/airports.py
+++ b/src/bokeh_sampledata/airports.py
@@ -30,7 +30,7 @@ from . import package_path
 
 __all__ = ("data",)
 
-with open(package_path("airports.json")) as f:
+with open(package_path("airports.json"), "rb") as f:
     airports = json.load(f)
     data = pd.json_normalize(
         airports["features"],

--- a/src/bokeh_sampledata/browsers.py
+++ b/src/bokeh_sampledata/browsers.py
@@ -38,7 +38,7 @@ __all__ = ("browsers_nov_2013", "icons")
 
 def _read_data() -> pd.DataFrame:
     df = package_csv("browsers_nov_2013.csv", names=("Version", "Share"), skiprows=1)
-    versions = df.Version.map(lambda x: x.rsplit(" ", 1))
+    versions = df["Version"].map(lambda x: x.rsplit(" ", 1))
     df["Browser"] = versions.map(lambda x: x[0])
     df["VersionNumber"] = versions.map(lambda x: x[1] if len(x) == 2 else "0")
     return df

--- a/src/bokeh_sampledata/sample_geojson.py
+++ b/src/bokeh_sampledata/sample_geojson.py
@@ -22,5 +22,5 @@ from . import package_path
 
 __all__ = ("geojson",)
 
-with open(package_path("sample_geojson.geojson")) as f:
+with open(package_path("sample_geojson.geojson"), encoding="utf-8") as f:
     geojson = f.read()

--- a/src/bokeh_sampledata/unemployment.py
+++ b/src/bokeh_sampledata/unemployment.py
@@ -37,7 +37,7 @@ __all__ = ("data",)
 
 data = {}
 
-with open(package_path("unemployment09.csv")) as f:
+with open(package_path("unemployment09.csv"), encoding="utf-8") as f:
     reader = csv.reader(f, delimiter=",", quotechar='"')
     for row in reader:
         _, state_id, county_id, _, _, _, _, _, rate = row

--- a/src/bokeh_sampledata/us_counties.py
+++ b/src/bokeh_sampledata/us_counties.py
@@ -70,7 +70,7 @@ class CountyData(TypedDict):
 def _read_data() -> dict[tuple[int, int], CountyData]:
     data: dict[tuple[int, int], CountyData] = {}
 
-    with open(package_path("US_Counties.csv")) as f:
+    with open(package_path("US_Counties.csv"), encoding="utf-8") as f:
         next(f)
         reader = csv.reader(f, delimiter=",", quotechar='"')
         for row in reader:

--- a/src/bokeh_sampledata/us_holidays.py
+++ b/src/bokeh_sampledata/us_holidays.py
@@ -37,7 +37,7 @@ from . import package_path
 
 __all__ = ("us_holidays",)
 
-with open(package_path("USHolidays.ics")) as f:
+with open(package_path("USHolidays.ics"), encoding="utf-8") as f:
     data = ic.Calendar.from_ical(f.read())
 
 us_holidays = sorted((elt.get("dtstart").dt, str(elt.get("summary"))) for elt in data.walk() if elt.name == "VEVENT")


### PR DESCRIPTION
- add `"rb"` and `encoding="utf-8"` to several `with open()` clauses, to avoid encoding errors on specific user environment.
- use `df[“Version"]` rather than `df.Version` to avoid mypy type check error