### PR TITLE
Fix unnamed index column in cycling dataset

### DIFF
--- a/src/bokeh_sampledata/cycling.py
+++ b/src/bokeh_sampledata/cycling.py
@@ -30,7 +30,7 @@ __all__ = ("cycling",)
 
 
 def _read_data() -> pd.DataFrame:
-    df = package_csv("cycling.csv")
+    df = package_csv("cycling.csv", index_col=0)
     df["time"] = pd.to_timedelta(df["time"])
     return df
 

--- a/tests/unit/bokeh_sampledata/test_cycling.py
+++ b/tests/unit/bokeh_sampledata/test_cycling.py
@@ -21,3 +21,14 @@ def test_cycling() -> None:
     assert isinstance(c.cycling, pd.DataFrame)
 
     assert len(c.cycling) == 4391
+    expected_columns = {
+        "position_lat",
+        "position_long",
+        "altitude",
+        "power",
+        "cadence",
+        "distance",
+        "speed",
+        "time",
+    }
+    assert set(c.cycling.columns) == expected_columns


### PR DESCRIPTION
This PR updates the loader for the cycling dataset to ignore the index column when reading the CSV file. It addresses an issue where `Unnamed: 0` appears as an unnecessary column due to the index being saved during CSV export.

I also updated the test.


**Before**
![image](https://github.com/user-attachments/assets/f8f7c38b-4cfa-43ee-b878-53c3cc4ab121)

**After**
![image](https://github.com/user-attachments/assets/ea09c753-148c-451b-917f-f6ca774f25c3)


